### PR TITLE
navbar DDT link resets the tool unexpectedly, so don't make it a link

### DIFF
--- a/demo/lib/directives/navbar/navbar.html
+++ b/demo/lib/directives/navbar/navbar.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-12">
         <div class="navbar-header">
-          <a class="navbar-brand" href="#">DDT</a>
+          DDT
         </div>
 
         <div class="collapse navbar-collapse">


### PR DESCRIPTION
On the top most navigation bar, the DDT "logo" is a link to `#`, but clicking that link reloads the whole tool and loses all families loaded which is unexpected and annoying :) 